### PR TITLE
Bumped ssh dependency because of Chef 13

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'cookbooks@monkeylittle.com'
 license          'MIT'
 description      'Installs/Configures jenkins_plugins'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '1.3.0'
+version          '1.4.0'
 
 depends 'jenkins'
 depends 'maven', '4.0.1'

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,7 +8,7 @@ version          '1.3.0'
 
 depends 'jenkins'
 depends 'maven', '4.0.1'
-depends 'ssh', '0.10.10'
+depends 'ssh', '0.10.20'
 
 issues_url 'https://github.com/monkeylittleinc/jenkins_plugins/issues'
 source_url 'https://github.com/monkeylittleinc/jenkins_plugins'


### PR DESCRIPTION
Chef 13 marks :default => TrueClass as error. Which is used in a resource in ssh 0.10.10 and fixed in 0.10.20